### PR TITLE
TJ-29 Reiniciar el nivel al perder una vida

### DIFF
--- a/src/characters/players/player.py
+++ b/src/characters/players/player.py
@@ -4,7 +4,7 @@ from characters.players.player_state import PlayerState
 
 
 class Player(Character):
-    def __init__(self, pos, surf, groups, lives, health_points):
+    def __init__(self, pos, surf, groups, health_points):
         super().__init__(pos, surf, groups)
 
         self.image = pygame.Surface((32, 32))
@@ -13,7 +13,6 @@ class Player(Character):
         self.rect = self.image.get_frect(topleft=pos)
         self.old_rect = self.rect.copy()
 
-        self.lives = lives
         self.health_points = health_points
         self.maximum_health_points = health_points
 
@@ -41,10 +40,7 @@ class Player(Character):
         if self.health_points > 0:
             return PlayerState.DAMAGED
 
-        self.lives -= 1
-        self.health_points = self.maximum_health_points
-
-        return PlayerState.GAME_OVER if self.lives <= 0 else PlayerState.DEAD
+        return PlayerState.DEAD
 
     def heal(self):
         has_max_health = self.health_points == self.maximum_health_points

--- a/src/characters/players/player_state.py
+++ b/src/characters/players/player_state.py
@@ -5,4 +5,3 @@ class PlayerState(Enum):
     ALIVE = auto()
     DAMAGED = auto()
     DEAD = auto()
-    GAME_OVER = auto()

--- a/src/director.py
+++ b/src/director.py
@@ -29,7 +29,7 @@ class Director():
             scene = self.stack[-1]
             self._loop(scene)
 
-    def exit_scene(self):
+    def pop_scene(self):
         self.exit_scene = True
         if (len(self.stack) > 0):
             self.stack.pop()
@@ -39,7 +39,7 @@ class Director():
         self.exit_scene = True
 
     def change_scene(self, scene):
-        self.exit_scene()
+        self.pop_scene()
         self.stack.append(scene)
 
     def stack_scene(self, scene):

--- a/src/scene/level.py
+++ b/src/scene/level.py
@@ -12,11 +12,12 @@ from berries.berrie_factory import berrie_factory
 from pygame.mixer import music
 from scene.scene import Scene
 from pytmx.util_pygame import load_pygame
+from director import Director
 import os
 
 
 class Level(Scene):
-    def __init__(self, director):
+    def __init__(self, director: Director):
         super().__init__(director)
         self.display_surface = pygame.display.get_surface()
         self.tmx_map = load_pygame(
@@ -81,8 +82,9 @@ class Level(Scene):
         return image_files
 
     def _setup_music(self):
-        music.load(self.music_file)
-        music.play(-1)
+        #music.load(self.music_file)
+        #music.play(-1)
+        pass
 
     def _setup_terrain(self):
         for x, y, surf in self.tmx_map.get_layer_by_name("Terrain").tiles():
@@ -148,14 +150,17 @@ class Level(Scene):
             case PlayerState.ALIVE:
                 pass
             case PlayerState.DAMAGED:
-                print(self.player.health_points)
                 if self.ui:
                     self.ui.draw_hearts()
                 pass
             case PlayerState.DEAD:
-                pass
+                self._handle_dead()
             case PlayerState.GAME_OVER:
                 pass
+
+    def _handle_dead(self):
+        self.director.exit_program()
+        self.director.stack_scene(Level(self.director))
 
     def update(self, delta_time):
         platform_rects = [

--- a/src/scene/level.py
+++ b/src/scene/level.py
@@ -17,7 +17,7 @@ import os
 
 
 class Level(Scene):
-    def __init__(self, director: Director):
+    def __init__(self, director: Director, remaining_lives = 3):
         super().__init__(director)
         self.display_surface = pygame.display.get_surface()
         self.tmx_map = load_pygame(
@@ -26,6 +26,7 @@ class Level(Scene):
             "assets", "maps", "backgrounds", "background1")
         self.music_file = join("assets", "sounds", "music", "level_1.ogg")
 
+        self.remaining_lives = remaining_lives
         self.player = None
         self.ui = None
 
@@ -71,7 +72,7 @@ class Level(Scene):
                 self.groups["backgrounds"],
             )
 
-    def _get_image_files(self,):
+    def _get_image_files(self):
         image_files = []
         for file in os.listdir(self.background_folder):
             if file.endswith(".png"):
@@ -108,7 +109,7 @@ class Level(Scene):
             (character.x, character.y),
             pygame.Surface((32, 32)),
             self.groups["all_sprites"],
-            lives=3 if DIFFICULTY == Difficulty.NORMAL else 1,
+            self.remaining_lives,
             health_points=5 if DIFFICULTY == Difficulty.NORMAL else 3
         )
         self.ui = UI(self.display_surface, self.player)

--- a/src/scene/level.py
+++ b/src/scene/level.py
@@ -17,7 +17,7 @@ import os
 
 
 class Level(Scene):
-    def __init__(self, director: Director, remaining_lives = 3):
+    def __init__(self, director: Director, remaining_lives=3):
         super().__init__(director)
         self.display_surface = pygame.display.get_surface()
         self.tmx_map = load_pygame(
@@ -83,8 +83,8 @@ class Level(Scene):
         return image_files
 
     def _setup_music(self):
-        #music.load(self.music_file)
-        #music.play(-1)
+        music.load(self.music_file)
+        music.play(-1)
         pass
 
     def _setup_terrain(self):
@@ -109,7 +109,6 @@ class Level(Scene):
             (character.x, character.y),
             pygame.Surface((32, 32)),
             self.groups["all_sprites"],
-            self.remaining_lives,
             health_points=5 if DIFFICULTY == Difficulty.NORMAL else 3
         )
         self.ui = UI(self.display_surface, self.player)
@@ -151,17 +150,13 @@ class Level(Scene):
             case PlayerState.ALIVE:
                 pass
             case PlayerState.DAMAGED:
-                if self.ui:
-                    self.ui.draw_hearts()
-                pass
+                self.ui.draw_hearts()
             case PlayerState.DEAD:
                 self._handle_dead()
-            case PlayerState.GAME_OVER:
-                pass
 
     def _handle_dead(self):
-        self.director.exit_program()
-        self.director.stack_scene(Level(self.director))
+        self.director.pop_scene()
+        self.director.stack_scene(Level(self.director, self.remaining_lives-1))
 
     def update(self, delta_time):
         platform_rects = [

--- a/src/scene/scene.py
+++ b/src/scene/scene.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
+from director import Director
 
 
 class Scene(ABC):
-    def __init__(self, director):
+    def __init__(self, director: Director):
         self.director = director
 
     @abstractmethod


### PR DESCRIPTION
Añadida la funcionalidad de reiniciar el nivel al perder una vida. Ahora el número de vidas restantes no la maneja la clase Player sino la clase Level. De esta forma, cuando el jugador pierde todas sus vidas, Level llama al director para que elimine la escena actual de la pila y cargue otra escena del mismo nivel, pero con una vida menos.

Las vidas las podría seguir manejando Player, de forma que cuando las pierde todas llame él al director, sin embargo lo veo un poco rebuscado porque para ello, a la nueva escena se le tendrían que pasar las vidas, y esta nueva escena le pasaría otra vez las vidas a la nueva instancia de Player.

Para implementar la pantalla de Game Over es necesario modificar la función de la clase Level _handle dead_, para comprobar si el jugador perdió todas las vidas. @inesfperez 